### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, development]


### PR DESCRIPTION
Potential fix for [https://github.com/reconka/Postie/security/code-scanning/5](https://github.com/reconka/Postie/security/code-scanning/5)

To fix the problem, define explicit `permissions` for the workflow so that the `GITHUB_TOKEN` is limited to the minimum needed, which here is read access to repository contents. Because all three jobs have similar, read-only interaction with GitHub (checkout and reading code), the cleanest and least intrusive change is to add a single `permissions` block at the top level of the workflow (alongside `name` and `on`). This will apply to all jobs unless they override it.

Concretely, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

right after the `name: CI` line (or anywhere at the root level before `jobs:`). This does not change any job steps or their functionality: `actions/checkout` works with `contents: read`, and all other commands operate locally or against external services using an explicit PAT (`AZURE_DEVOPS_PAT`). No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
